### PR TITLE
Corrige o overflow dos social icons no footer

### DIFF
--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -34,8 +34,9 @@ export const Social = styled.div`
   grid-area: Social;
 
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: flex-end;
+  flex-wrap: wrap-reverse;
   gap: 16px;
 `;
 


### PR DESCRIPTION
Pequenas alterações nos estilos do footer para permitir o flex-wrap, prevenindo o overflow em dispositivos móveis.